### PR TITLE
Bump commons-compress from 1.12 to 1.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.18</version>
+            <version>1.19</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Bumps commons-compress from 1.12 to 1.19.

Signed-off-by: dependabot[bot] <support@github.com>